### PR TITLE
fix(renew-certs): use kubeadm certs renew instead of alpha certs renew

### DIFF
--- a/master/tasks/phase_certs_renew.yml
+++ b/master/tasks/phase_certs_renew.yml
@@ -1,6 +1,6 @@
 ---
 - name: Kubeadm | Certs renew phase
   shell: |
-    {{ bin_dir }}/kubeadm alpha certs renew all --config kubeadm-config.yaml
+    {{ bin_dir }}/kubeadm certs renew all --config kubeadm-config.yaml
   args:
     chdir: "{{ kubeadm_exec_dir }}"


### PR DESCRIPTION
`kubeadm alpha certs` was deprecated in 1.20 and got removed in 1.21.

Graduation PR: https://github.com/kubernetes/kubernetes/pull/94938
Removal PR: https://github.com/kubernetes/kubernetes/pull/97706

Signed-off-by: Theo Bob Massard <tbobm@protonmail.com>